### PR TITLE
fix asdf install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,13 +10,15 @@ else
 	rm -rf ${ASDF_INSTALL_VERSION}*
 
 	VERSION=$(echo $ASDF_INSTALL_VERSION | sed -e "s#^.*-##")
-	curl -OJL https://github.com/micronaut-projects/micronaut-core/releases/download/v$VERSION/${ASDF_INSTALL_VERSION}.zip
-	unzip ${ASDF_INSTALL_VERSION}.zip -d ${ASDF_INSTALL_VERSION}
-	rm ${ASDF_INSTALL_VERSION}.zip
+	FILE_NAME="micronaut-${ASDF_INSTALL_VERSION}"
+	ZIP="${FILE_NAME}.zip"
+	curl -OJL https://github.com/micronaut-projects/micronaut-core/releases/download/v${VERSION}/${ZIP}
+	unzip ${ZIP} -d ${FILE_NAME}
+	rm ${ZIP}
 
-	mv ${ASDF_INSTALL_VERSION}/*/* ${ASDF_INSTALL_VERSION}/ 
-	rm -rf ${ASDF_INSTALL_VERSION}/${ASDF_INSTALL_VERSION} 
-	cp -R ${ASDF_INSTALL_VERSION}/* .
+	mv ${FILE_NAME}/*/* ${FILE_NAME}/ 
+	rm -rf ${FILE_NAME}/${FILE_NAME} 
+	cp -R ${FILE_NAME}/* .
 	
-	chmod +x ${ASDF_INSTALL_VERSION}/bin/*
+	chmod +x ${FILE_NAME}/bin/*
 fi


### PR DESCRIPTION
Micronaut names their zip artifacts like `micronaut-1.1.4.zip` ([reference](https://github.com/micronaut-projects/micronaut-core/releases/tag/v1.1.4))