### PR TITLE
Update list-all to use atom feed

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -13,7 +13,26 @@ else
 		VERSION=$(echo $ASDF_INSTALL_VERSION | sed -e "s#^.*-##")
 		FILE_NAME="micronaut-${ASDF_INSTALL_VERSION}"
 		ZIP="${FILE_NAME}.zip"
-		curl -OJL https://github.com/micronaut-projects/micronaut-core/releases/download/v${VERSION}/${ZIP}
+		DOWNLOAD_URL=https://github.com/micronaut-projects/micronaut-core/releases/download/v${VERSION}/${ZIP}
+
+		# 2.0.0 onwards use a different download URL
+		if [[ "2.0.0" =~ ^2\.[0-9]+\.[0-9]+$ ]]; then
+			unameOut="$(uname -s)"
+			case "${unameOut}" in
+				Linux*)     machine=linux;;
+				Darwin*)    machine=darwin;;
+				CYGWIN*|MINGW32*|MSYS*|MINGW*)    machine=win;;
+				*)          machine="UNKNOWN"
+			esac
+			echo ${machine}
+			FILE_NAME="mn-${machine}-amd64-v${ASDF_INSTALL_VERSION}"
+			ZIP="${FILE_NAME}.zip"
+			DOWNLOAD_URL=https://github.com/micronaut-projects/micronaut-starter/releases/download/v${ASDF_INSTALL_VERSION}/${ZIP}
+		fi
+
+
+		ZIP="${FILE_NAME}.zip"
+		curl -OJL $DOWNLOAD_URL
 		unzip -o ${ZIP}
 		rm ${ZIP}
 

--- a/bin/install
+++ b/bin/install
@@ -19,13 +19,13 @@ else
 		if [[ "2.0.0" =~ ^2\.[0-9]+\.[0-9]+$ ]]; then
 			unameOut="$(uname -s)"
 			case "${unameOut}" in
-				Linux*)     machine=linux;;
-				Darwin*)    machine=darwin;;
-				CYGWIN*|MINGW32*|MSYS*|MINGW*)    machine=win;;
-				*)          machine="UNKNOWN"
+				Linux*)     OS_TYPE=linux;;
+				Darwin*)    OS_TYPE=darwin;;
+				CYGWIN*|MINGW32*|MSYS*|MINGW*)    OS_TYPE=win;;
+				*)          OS_TYPE="UNKNOWN"
 			esac
-			echo ${machine}
-			FILE_NAME="mn-${machine}-amd64-v${ASDF_INSTALL_VERSION}"
+			
+			FILE_NAME="mn-${OS_TYPE}-amd64-v${ASDF_INSTALL_VERSION}"
 			ZIP="${FILE_NAME}.zip"
 			DOWNLOAD_URL=https://github.com/micronaut-projects/micronaut-starter/releases/download/v${ASDF_INSTALL_VERSION}/${ZIP}
 		fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -s https://github.com/micronaut-projects/micronaut-core/releases.atom | grep -e ".*micronaut-core/releases/tag.*\"" | sed -n -e 's#^.*releases/tag/v\([^\"]*\)"/>#\1#p' | paste -s -d" " -
+curl -s https://github.com/micronaut-projects/micronaut-core/releases.atom | grep -e ".*micronaut-core/releases/tag.*\"" | sed -n -e 's#^.*releases/tag/v\([^\"]*\)"/>#\1#p' | sort -t. -n | paste -s -d" " -

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,3 @@
 #!/bin/bash
-curl -s https://github.com/micronaut-projects/micronaut-core/releases | grep -e ".*releases/.*micronaut.*.zip\"" | sed -e "s#^.*/v.*/##" -e "s#.zip.*##" -e "s#.*-##" | sort -t. -n | paste -s -d" " -
-#curl -s https://github.com/micronaut-projects/micronaut-core/releases | grep -e ".*releases/.*micronaut.*.zip\"" | sed -e "s#^.*/v.*/##" -e "s#.zip.*##" -e "s#.*-##" | sort -t. -n | paste -s -d" " -
+
+curl -s https://github.com/micronaut-projects/micronaut-core/releases.atom | grep -e ".*micronaut-core/releases/tag.*\"" | sed -n -e 's#^.*releases/tag/v\([^\"]*\)"/>#\1#p' | paste -s -d" " -


### PR DESCRIPTION
Fixes #2 

Using the atom feed gives  more reliable parsing, as it's just data,
not presentation html.

Now returns '2.0.0' properly.  And can handle the new download location for version 2.0.0